### PR TITLE
Bounty: Enable fixed ordering of top nav items

### DIFF
--- a/data/docs.yaml
+++ b/data/docs.yaml
@@ -2,6 +2,7 @@ title: Docs
 color: green
 icon: stroke_decentralization
 description: Dash Platorm Documentation resources.
+weight: 10
 content:
   - title: DashJS
     website: https://dashevo.github.io/DashJS

--- a/data/tools.yaml
+++ b/data/tools.yaml
@@ -2,6 +2,7 @@ title: Tools
 color: yellow
 icon: stroke_code
 description: Tools for developing with Dash Platform.
+weight: 6
 content:
 - title: EvoNet Faucet
   website: http://devnet-evonet-1117662964.us-west-2.elb.amazonaws.com/

--- a/package-lock.json
+++ b/package-lock.json
@@ -184,9 +184,9 @@
       }
     },
     "acorn": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
       "dev": true
     },
     "acorn-jsx": {
@@ -3750,9 +3750,9 @@
       }
     },
     "kind-of": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
     "labeled-stream-splicer": {

--- a/scripts/data.js
+++ b/scripts/data.js
@@ -13,10 +13,11 @@ module.exports = fs.readdirSync(dir)
     file.slug = slugify(file.title)
     file.type = 'category'
 
-    file.content = file.content.map(({ title, description, ...meta }, i) => ({
+    file.content = file.content.map(({ title, description, weight, ...meta }, i) => ({
       ...meta,
       title: trimIfExists(title),
       description: trimIfExists(description),
+      weight: weight,
       category: file.slug,
       color: file.color,
       index: i
@@ -32,3 +33,4 @@ module.exports = fs.readdirSync(dir)
     return file
   })
   .sort((a, b) => sortAbc(a.title, b.title))
+  .sort((a, b) => sortInv(a.weight, b.weight))


### PR DESCRIPTION
## What kind of change is it?

- [ ] Addition
- [ ] Removal
- [ ] Edit
- [x] Other ([Site improvement bounty](https://trello.com/c/iN58zxs0/19-dashdevsorg-work))

## Details

Adds a new parameter, `weight`, to category YAML files. Adds sorting rules in `scripts/data.js` to sort categories using this parameter. Low weight is further to the left. Any weight is "lighter" than no weight at all. The original sorting by title remains in place as a default.

It would be helpful to know what ordering is desired; I have moved Docs and Tools to the beginning just to prove it works, but this can be edited to give the actual desired ordering.