### PR TITLE
feat: add footer nav menu

### DIFF
--- a/src/config/_default/config.yaml
+++ b/src/config/_default/config.yaml
@@ -1,0 +1,15 @@
+baseurl: ''
+relativeurls: true
+languageCode: en
+pluralizelisttitles: false
+removePathAccents: true
+title: Awesome Dash Platform
+
+disableKinds:
+  - taxonomyTerm
+
+params:
+  Description: >-
+    Useful resources for building things on top of Dash Platform
+  Image: >-
+    https://dashdevs.org/images/brand/dash_logo_2018_rgb_for_screens.png

--- a/src/config/_default/menus.yaml
+++ b/src/config/_default/menus.yaml
@@ -1,0 +1,11 @@
+footer:
+- name: Chat
+  url: https://chat.dashdevs.org
+- name: Bounties
+  url: https://bounties.dashdevs.org
+- name: Github
+  url: https://github.com/andyfreer/awesome-dash-platform
+- name: Get Listed
+  url: https://github.com/andyfreer/awesome-dash-platform/blob/master/CONTRIBUTING.md
+- name: Dash.org
+  url: https://dash.org

--- a/src/layouts/_default/baseof.html
+++ b/src/layouts/_default/baseof.html
@@ -28,12 +28,14 @@
     </nav>
     {{ template "main" . }}
 
-    <footer class="mv4 montserrat ttu tc snow tracked b">
-      <a target="_blank" href="https://github.com/andyfreer/awesome-dash-platform" class="snow no-underline">Github</a> |
-      <a target="_blank" href="https://github.com/andyfreer/awesome-dash-platform/blob/master/CONTRIBUTING.md" class="snow no-underline"> Get Listed</a> |
-      <a target="_blank" href="https://www.dash.org" class="snow no-underline">Dash.org</a>
-    </footer>
   </div>
+  <footer class="mt2 pv4 w-90 mw9 center montserrat ttu snow tracked b bg-dark-blue">
+    <nav class="ph3" style="column-width: 12em">
+      {{ range .Site.Menus.footer }}
+        <a target="_blank" class="snow no-underline db" href="{{ .URL }}">{{ .Name }}</a>
+      {{ end }}
+    </nav>
+  </footer>
   <script src='{{ .Site.BaseURL }}/app.js'></script>
 </body>
 </html>


### PR DESCRIPTION
This site enhancement adds a footer menu. Footer menu links can be added in `src/config/_default/menus.yaml`. There is room for an unlimited number of links, which will be divided as evenly as possible into columns. For now there is no attempt to categorize footer links.
![image](https://user-images.githubusercontent.com/2583159/77829322-aecb1800-70f7-11ea-842f-e15f648af252.png)
